### PR TITLE
Fix link to Open Government Licence – Jersey v1.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@
       <div class="twelve column">
         <footer>
 
-          <p>A <a href="http://www.bearpig.com" target="_blank">bearpig</a> hack using data produced by the Government of Jersey via <a href="https://opendata.gov.je/dataset/coronavirus-covid-19-number-of-cases-in-jersey">Open Data Portal</a> under the <a href="Open Government Licence – Jersey v1.0" target="_blank">OPL-J Licence</a>.<br/> You can find the project on Github <a href="https://github.com/bearpig/COVID19_org_je" target="_blank"> here.</a></p>
+          <p>A <a href="http://www.bearpig.com" target="_blank">bearpig</a> hack using data produced by the Government of Jersey via <a href="https://opendata.gov.je/dataset/coronavirus-covid-19-number-of-cases-in-jersey">Open Data Portal</a> under the <a href="https://opendata.gov.je/pages/open-government-licence-jersey-ogl-j-v1-0" target="_blank">OPL-J Licence</a>.<br/> You can find the project on Github <a href="https://github.com/bearpig/COVID19_org_je" target="_blank"> here.</a></p>
           <p>#StayHomeStaySafe</p>
           <div class="credit">
             


### PR DESCRIPTION
Fix the link to the Open Government Licence – Jersey v1.0
https://opendata.gov.je/pages/open-government-licence-jersey-ogl-j-v1-0